### PR TITLE
feat: [DBI-477] Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dailypay/devrel @dailypay/Integrations


### PR DESCRIPTION
What
Add code owners file

Why
It is required to enforce PR reviews by code owners

Related Links
[JIRA](https://dailypay.atlassian.net/browse/DBI-477)
